### PR TITLE
Fix to_json

### DIFF
--- a/epcore/elements/board.py
+++ b/epcore/elements/board.py
@@ -75,6 +75,8 @@ class Board(JsonConvertible):
         Return dict with structure compatible with UFIV JSON file schema.
         :return: dict with information about board.
         """
-
-        return {"elements": [el.to_json() for el in self.elements],
-                "version": version}
+        json_data = {"elements": [el.to_json() for el in self.elements],
+                     "version": version}
+        if self.pcb is not None:
+            json_data["PCB"] = self.pcb.to_json()
+        return json_data

--- a/epcore/measurementmanager/tests/test_utils.py
+++ b/epcore/measurementmanager/tests/test_utils.py
@@ -36,7 +36,7 @@ class TestPlan(unittest.TestCase):
         measurer.set_settings(optimal_settings)
         settings_after_search = measurer.get_settings()
         # The measurer should have new settings set
-        self.assertTrue(settings_after_search is optimal_settings)
+        self.assertTrue(settings_after_search is optimal_settings)  # TODO: "is" is just a pointer
 
     def test_optimal_settings_resistor(self):
         measurer = IVMeasurerVirtual()


### PR DESCRIPTION
При выполнении этого кода, board_to_save и board_loaded различаются, в board_loaded теряется pcb
```python
from epcore.elements import Board
from epcore.filemanager import save_board_to_ufiv, load_board_from_ufiv

board_dict = {'version': '1.1.2',
              'PCB': {"pcb_name": "TEST", "comment": "MY_COMMENT"},
              'elements': [{'pins': [{'iv_curves': [], 'x': 0, 'y': 0}]}]}
board_to_save = Board.create_from_json(board_dict)
save_board_to_ufiv('test.uzf', board_to_save)
board_loaded = load_board_from_ufiv('test.uzf')
```

Проблема была в методе `Board.to_json()`, в нём не выполнялось преобразование pcb в json, соответственно в сохранённый файл pcb не попадало.